### PR TITLE
[seeding]: Utilize drizzle seed and upgrade drizzle

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -7,3 +7,4 @@ Linking the PRs in the order they were created and merged here for easy finding:
 
 1. [[bugs]: Addressing initial bugs and issues](https://github.com/solomonjames/solace-candidate-assignment/pull/1)
 2. [[migrations]: Adding migrations and using drizzle to run them](https://github.com/solomonjames/solace-candidate-assignment/pull/2)
+3. [[seeding]: Utilize drizzle seed and upgrade drizzle](https://github.com/solomonjames/solace-candidate-assignment/pull/3)

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ docker compose up -d
 3. Push migration to the database
 
 ```bash
-npm run migrate
+npm run db:migrate
 ```
 
 4. Seed the database
 
 ```bash
-npm run seed
+npm run db:seed
 ```
 
 ## Development
@@ -47,13 +47,15 @@ npm run seed
 When adding new database schemas to the project, we should make sure a related seeder is also created, unless
 it is somehow not applicable to that data.
 
+> You can also reset the database, and truncate tables using `npm run db:reset`
+
 ### Migrations
 
 Ensure that you generate and commit the generated sql migration files during development.
 
 With Drizzle this should be really straight forward, and done in a couple small steps.
 
-1. `npm run generate`
-2. `npm run migrate`
+1. `npm run db:generate`
+2. `npm run db:migrate`
 
 Generate will create the new sql migrations, and migrate will apply them!

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ npm run seed
 
 ## Development
 
+### Seeding
+
+When adding new database schemas to the project, we should make sure a related seeder is also created, unless
+it is somehow not applicable to that data.
+
 ### Migrations
 
 Ensure that you generate and commit the generated sql migration files during development.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@next/env": "^15.5.3",
-        "drizzle-orm": "^0.32.1",
+        "drizzle-orm": "^0.39.3",
         "next": "^14.2.19",
         "postgres": "^3.4.4",
         "react": "^18.3.1",
@@ -20,6 +20,7 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "drizzle-kit": "^0.23.0",
+        "drizzle-seed": "^0.3.1",
         "eslint": "^8.57.0",
         "eslint-config-next": "14.2.5",
         "postcss": "^8.4.40",
@@ -1308,13 +1309,13 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1994,7 +1995,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2162,15 +2163,16 @@
       }
     },
     "node_modules/drizzle-orm": {
-      "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.32.2.tgz",
-      "integrity": "sha512-3fXKzPzrgZIcnWCSLiERKN5Opf9Iagrag75snfFlKeKSYB1nlgPBshzW3Zn6dQymkyiib+xc4nIz0t8U+Xdpuw==",
+      "version": "0.39.3",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.39.3.tgz",
+      "integrity": "sha512-EZ8ZpYvDIvKU9C56JYLOmUskazhad+uXZCTCRN4OnRMsL+xAJ05dv1eCpAG5xzhsm1hqiuC5kAZUCS924u2DTw==",
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
-        "@cloudflare/workers-types": ">=3",
-        "@electric-sql/pglite": ">=0.1.1",
-        "@libsql/client": "*",
-        "@neondatabase/serverless": ">=0.1",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
         "@op-engineering/op-sqlite": ">=2",
         "@opentelemetry/api": "^1.4.1",
         "@planetscale/database": ">=1",
@@ -2178,19 +2180,17 @@
         "@tidbcloud/serverless": "*",
         "@types/better-sqlite3": "*",
         "@types/pg": "*",
-        "@types/react": ">=18",
         "@types/sql.js": "*",
         "@vercel/postgres": ">=0.8.0",
         "@xata.io/client": "*",
         "better-sqlite3": ">=7",
         "bun-types": "*",
-        "expo-sqlite": ">=13.2.0",
+        "expo-sqlite": ">=14.0.0",
         "knex": "*",
         "kysely": "*",
         "mysql2": ">=2",
         "pg": ">=8",
         "postgres": ">=3",
-        "react": ">=18",
         "sql.js": ">=1",
         "sqlite3": ">=5"
       },
@@ -2205,6 +2205,9 @@
           "optional": true
         },
         "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
           "optional": true
         },
         "@neondatabase/serverless": {
@@ -2229,9 +2232,6 @@
           "optional": true
         },
         "@types/pg": {
-          "optional": true
-        },
-        "@types/react": {
           "optional": true
         },
         "@types/sql.js": {
@@ -2270,13 +2270,27 @@
         "prisma": {
           "optional": true
         },
-        "react": {
-          "optional": true
-        },
         "sql.js": {
           "optional": true
         },
         "sqlite3": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/drizzle-seed": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/drizzle-seed/-/drizzle-seed-0.3.1.tgz",
+      "integrity": "sha512-F/0lgvfOAsqlYoHM/QAGut4xXIOXoE5VoAdv2FIl7DpGYVXlAzKuJO+IphkKUFK3Dz+rFlOsQLnMNrvoQ0cx7g==",
+      "dev": true,
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "peerDependencies": {
+        "drizzle-orm": ">=0.36.4"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
           "optional": true
         }
       }
@@ -4739,6 +4753,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@next/env": "^15.5.3",
-    "drizzle-orm": "^0.32.1",
+    "drizzle-orm": "^0.39.3",
     "next": "^14.2.19",
     "postgres": "^3.4.4",
     "react": "^18.3.1",
@@ -24,6 +24,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "drizzle-kit": "^0.23.0",
+    "drizzle-seed": "^0.3.1",
     "eslint": "^8.57.0",
     "eslint-config-next": "14.2.5",
     "postcss": "^8.4.40",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "generate": "drizzle-kit generate",
-    "migrate": "drizzle-kit migrate",
-    "seed": "tsx --env-file=.env.development ./src/db/seed/index.ts"
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:seed": "tsx --env-file=.env.development ./src/db/seed/index.ts",
+    "db:reset": "tsx --env-file=.env.development ./src/db/reset.ts"
   },
   "dependencies": {
     "@next/env": "^15.5.3",

--- a/src/db/reset.ts
+++ b/src/db/reset.ts
@@ -1,0 +1,16 @@
+import db from '@/db';
+import { reset } from "drizzle-seed";
+import { advocates } from '@/db/schema/advocates';
+
+async function main() {
+  if (process.env.NODE_ENV === 'production') {
+    console.error('This should not be run in production!');
+    process.exit(1);
+  }
+
+  await reset(db, { advocates });
+}
+
+main().then(() => {
+  process.exit(0);
+}).catch(() => process.exit(1));

--- a/src/db/seed/advocates.ts
+++ b/src/db/seed/advocates.ts
@@ -1,3 +1,7 @@
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { seed } from 'drizzle-seed';
+import { advocates } from '@/db/schema/advocates';
+
 const specialties = [
   "Bipolar",
   "LGBTQ",
@@ -27,149 +31,31 @@ const specialties = [
   "Domestic abuse",
 ];
 
-const randomSpecialty = () => {
-  const random1 = Math.floor(Math.random() * 24);
-  const random2 = Math.floor(Math.random() * (24 - random1)) + random1 + 1;
+const degrees = ["MD", "PhD", "MSW", "MD"];
 
-  return [random1, random2];
-};
-
-const advocateData = [
-  {
-    firstName: "John",
-    lastName: "Doe",
-    city: "New York",
-    degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 10,
-    phoneNumber: "5551234567",
-  },
-  {
-    firstName: "Jane",
-    lastName: "Smith",
-    city: "Los Angeles",
-    degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 8,
-    phoneNumber: "5559876543",
-  },
-  {
-    firstName: "Alice",
-    lastName: "Johnson",
-    city: "Chicago",
-    degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 5,
-    phoneNumber: "5554567890",
-  },
-  {
-    firstName: "Michael",
-    lastName: "Brown",
-    city: "Houston",
-    degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 12,
-    phoneNumber: "5556543210",
-  },
-  {
-    firstName: "Emily",
-    lastName: "Davis",
-    city: "Phoenix",
-    degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 7,
-    phoneNumber: "5553210987",
-  },
-  {
-    firstName: "Chris",
-    lastName: "Martinez",
-    city: "Philadelphia",
-    degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 9,
-    phoneNumber: "5557890123",
-  },
-  {
-    firstName: "Jessica",
-    lastName: "Taylor",
-    city: "San Antonio",
-    degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 11,
-    phoneNumber: "5554561234",
-  },
-  {
-    firstName: "David",
-    lastName: "Harris",
-    city: "San Diego",
-    degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 6,
-    phoneNumber: "5557896543",
-  },
-  {
-    firstName: "Laura",
-    lastName: "Clark",
-    city: "Dallas",
-    degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 4,
-    phoneNumber: "5550123456",
-  },
-  {
-    firstName: "Daniel",
-    lastName: "Lewis",
-    city: "San Jose",
-    degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 13,
-    phoneNumber: "5553217654",
-  },
-  {
-    firstName: "Sarah",
-    lastName: "Lee",
-    city: "Austin",
-    degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 10,
-    phoneNumber: "5551238765",
-  },
-  {
-    firstName: "James",
-    lastName: "King",
-    city: "Jacksonville",
-    degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 5,
-    phoneNumber: "5556540987",
-  },
-  {
-    firstName: "Megan",
-    lastName: "Green",
-    city: "San Francisco",
-    degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 14,
-    phoneNumber: "5559873456",
-  },
-  {
-    firstName: "Joshua",
-    lastName: "Walker",
-    city: "Columbus",
-    degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 9,
-    phoneNumber: "5556781234",
-  },
-  {
-    firstName: "Amanda",
-    lastName: "Hall",
-    city: "Fort Worth",
-    degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 3,
-    phoneNumber: "5559872345",
-  },
-];
-
-export { advocateData };
+export function advocatesSeeder(db: PostgresJsDatabase, count: number = 100) {
+  return seed(db, { advocates }, { count })
+    .refine((funcs) => ({
+      advocates: {
+        columns: {
+          specialties: funcs.valuesFromArray({
+            values: specialties,
+            isUnique: false,
+            arraySize: 2,
+          }),
+          degree: funcs.valuesFromArray({
+            values: degrees,
+            isUnique: false,
+          }),
+          yearsOfExperience: funcs.int({
+            minValue: 1,
+            maxValue: 70,
+          }),
+          phoneNumber: funcs.phoneNumber({
+            template: "+1 ###-####"
+          }),
+          city: funcs.city({}),
+        },
+      },
+    }));
+}

--- a/src/db/seed/index.ts
+++ b/src/db/seed/index.ts
@@ -1,6 +1,5 @@
-import db from "../index";
-import { advocates } from "../schema/advocates";
-import { advocateData } from "./advocates";
+import db from "@/db";
+import { advocatesSeeder } from "@/db/seed/advocates";
 
 async function seed() {
   if (!process.env.DATABASE_URL) {
@@ -9,7 +8,7 @@ async function seed() {
   }
 
   try {
-    await db.insert(advocates).values(advocateData);
+    await advocatesSeeder(db, 50);
     console.log("Seeded advocates successfully");
 
     process.exit(0);


### PR DESCRIPTION
# What Changed?

Utilizing the Drizzle Seed library will enable a more scalable solution to seeding a dev database. It can fake more data, be configurable to more entries, and make it easy as we add new tables and schemas to seed that data as well.

## Database
- Require `drizzle-seed`, which required a update to `drizzle-orm`
- Update the advocates seeder to utilize the drizzle seed method
  - Updating that to ensure fake data is realistic
- Adding a script to reset the database `npm run db:reset` which truncates tables

## Screenshot/Video

## Related PRs

### Reminders

- Link to the related ticket
- Tests added or updated
- Add/Update related documentation
