### PR TITLE
[database]: Start using Repositories instead of direct queries

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -8,3 +8,4 @@ Linking the PRs in the order they were created and merged here for easy finding:
 1. [[bugs]: Addressing initial bugs and issues](https://github.com/solomonjames/solace-candidate-assignment/pull/1)
 2. [[migrations]: Adding migrations and using drizzle to run them](https://github.com/solomonjames/solace-candidate-assignment/pull/2)
 3. [[seeding]: Utilize drizzle seed and upgrade drizzle](https://github.com/solomonjames/solace-candidate-assignment/pull/3)
+4. [[database]: Start using Repositories instead of direct queries](https://github.com/solomonjames/solace-candidate-assignment/pull/4)

--- a/README.md
+++ b/README.md
@@ -59,3 +59,13 @@ With Drizzle this should be really straight forward, and done in a couple small 
 2. `npm run db:migrate`
 
 Generate will create the new sql migrations, and migrate will apply them!
+
+### New Schema Checklist
+
+Creating a new schema for the database? Here is a little checklist as a reminder of what is expected with
+each new schema.
+
+1. Create new schema file with export types and table
+2. Create seeder, if applicable
+3. Generate migration
+4. Create new repository class

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,8 +1,9 @@
 import db from "@/db";
-import { advocates } from "@/db/schema/advocates";
+import { AdvocateRepository } from '@/lib/repositories';
 
 export async function GET() {
-  const data = await db.select().from(advocates);
+  const advocateRepository = new AdvocateRepository(db);
+  const data = await advocateRepository.findAll();
 
   return Response.json({ data });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { type AdvocateEntity } from '@/db/schema';
 
 export default function Home() {
-  const [advocates, setAdvocates] = useState([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState([]);
+  const [advocates, setAdvocates] = useState<AdvocateEntity[]>([]);
+  const [filteredAdvocates, setFilteredAdvocates] = useState<AdvocateEntity[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
 
   useEffect(() => {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,7 +1,13 @@
 import { drizzle, PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
+let databaseInstance: PostgresJsDatabase | null = null;
+
 const setup = (): PostgresJsDatabase => {
+  if (databaseInstance) {
+    return databaseInstance;
+  }
+
   if (!process.env.DATABASE_URL) {
     console.error("DATABASE_URL is not set");
 
@@ -10,8 +16,9 @@ const setup = (): PostgresJsDatabase => {
 
   // for query purposes
   const queryClient = postgres(process.env.DATABASE_URL);
+  databaseInstance = drizzle(queryClient);
 
-  return drizzle(queryClient);
+  return databaseInstance;
 };
 
 export default setup();

--- a/src/db/reset.ts
+++ b/src/db/reset.ts
@@ -1,6 +1,6 @@
 import db from '@/db';
 import { reset } from "drizzle-seed";
-import { advocates } from '@/db/schema/advocates';
+import { advocatesTable } from '@/db/schema';
 
 async function main() {
   if (process.env.NODE_ENV === 'production') {
@@ -8,7 +8,7 @@ async function main() {
     process.exit(1);
   }
 
-  await reset(db, { advocates });
+  await reset(db, { advocates: advocatesTable });
 }
 
 main().then(() => {

--- a/src/db/schema/advocates.ts
+++ b/src/db/schema/advocates.ts
@@ -7,14 +7,16 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 
-export const advocates = pgTable("advocates", {
+export const advocatesTable = pgTable("advocates", {
   id: serial("id").primaryKey(),
   firstName: varchar("first_name").notNull(),
   lastName: varchar("last_name").notNull(),
   city: varchar("city").notNull(),
   degree: varchar("degree", { length: 100 }).notNull(),
-  specialties: jsonb("specialties").default([]).notNull(),
+  specialties: jsonb("specialties").default([]).notNull().$type<string[]>(),
   yearsOfExperience: smallint("years_of_experience").notNull(),
   phoneNumber: varchar("phone_number").notNull(),
   createdAt: timestamp("created_at").defaultNow()
 });
+
+export type AdvocateEntity = typeof advocatesTable.$inferSelect;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,0 +1,1 @@
+export * from '@/db/schema/advocates';

--- a/src/db/seed/advocates.ts
+++ b/src/db/seed/advocates.ts
@@ -1,6 +1,6 @@
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { seed } from 'drizzle-seed';
-import { advocates } from '@/db/schema/advocates';
+import { advocatesTable } from '@/db/schema/advocates';
 
 const specialties = [
   "Bipolar",
@@ -34,7 +34,7 @@ const specialties = [
 const degrees = ["MD", "PhD", "MSW", "MD"];
 
 export function advocatesSeeder(db: PostgresJsDatabase, count: number = 100) {
-  return seed(db, { advocates }, { count })
+  return seed(db, { advocates: advocatesTable }, { count })
     .refine((funcs) => ({
       advocates: {
         columns: {

--- a/src/lib/repositories/advocate-repository.ts
+++ b/src/lib/repositories/advocate-repository.ts
@@ -1,0 +1,10 @@
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { AdvocateEntity, advocatesTable } from '@/db/schema';
+
+export class AdvocateRepository {
+  constructor(private readonly db: PostgresJsDatabase) {}
+
+  async findAll(): Promise<AdvocateEntity[]> {
+    return this.db.select().from(advocatesTable);
+  }
+}

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -1,0 +1,1 @@
+export * from '@/lib/repositories/advocate-repository';


### PR DESCRIPTION
# What Changed?

Time to start adding some abstractions for the data layer. Introducing a simple repository pattern for our schemas. This helps with a few things over time. For one it can make testing easier, as you have now abstracted the fetching of the data. It also helps centralize more complex queries somewhere reusable.

**NOTE:** We still aren't doing clean dependency injection, so there are still issues with a hard-coded class instantiation of the repository class. However this is still a step in the right direction.

- Introducing a `lib` folder to house shared reusable code
- Specifically adding in a new `repositories` namespace
- Updating the `page.tsx` to have types now for the data retrieved from the endpoint
- Updated the advocates schema to export the inferred select type, and fixing the type for specialties
- Updated the database connection setup to be a singleton
  - Singletons for a database connection can help reduce the load to make a new connection every time

## Screenshot/Video

n/a

## Related PRs


### Reminders

- Link to the related ticket
- Tests added or updated
- Add/Update related documentation
