### PR TITLE
[api]: Creating API SDK for the client to use when talking to backend

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 #DATABASE_URL=
+#API_URL=

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment
+API_URL=http://localhost:3000

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import { ReactNode } from 'react';
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -12,7 +13,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <html lang="en">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { type AdvocateEntity } from '@/db/schema';
+import { advocateApi } from '@/lib/api';
 
 export default function Home() {
   const [advocates, setAdvocates] = useState<AdvocateEntity[]>([]);
@@ -10,11 +11,9 @@ export default function Home() {
 
   useEffect(() => {
     console.log("fetching advocates...");
-    fetch("/api/advocates").then((response) => {
-      response.json().then((jsonResponse) => {
-        setAdvocates(jsonResponse.data);
-        setFilteredAdvocates(jsonResponse.data);
-      });
+    advocateApi.fetchAll().then((data) => {
+        setAdvocates(data.data);
+        setFilteredAdvocates(data.data);
     });
   }, []);
 
@@ -24,7 +23,7 @@ export default function Home() {
     setSearchTerm(value);
 
     console.log("filtering advocates...");
-    const filteredAdvocates = advocates.filter((advocate) => {
+    const filtered = advocates.filter((advocate) => {
       return (
         advocate.firstName.includes(searchTerm) ||
         advocate.lastName.includes(searchTerm) ||
@@ -35,7 +34,7 @@ export default function Home() {
       );
     });
 
-    setFilteredAdvocates(filteredAdvocates);
+    setFilteredAdvocates(filtered);
   };
 
   const onClick = () => {

--- a/src/lib/api/advocate-api.ts
+++ b/src/lib/api/advocate-api.ts
@@ -1,0 +1,12 @@
+import { ApiClient, ApiResponse } from '@/lib/api/api-client';
+import { AdvocateEntity } from '@/db/schema';
+
+export class AdvocateApi {
+  constructor(
+    private readonly client: ApiClient
+  ) {}
+
+  async fetchAll(): Promise<ApiResponse<AdvocateEntity[]>> {
+    return this.client.get('/api/advocates');
+  }
+}

--- a/src/lib/api/api-client.ts
+++ b/src/lib/api/api-client.ts
@@ -1,0 +1,46 @@
+export interface ApiConfig {
+  baseUrl: string;
+  headers?: Record<string, string>;
+}
+
+export interface ApiResponse<T> {
+  data: T;
+}
+
+export class ApiClient {
+  private readonly baseUrl: string;
+  private readonly headers: Record<string, string>;
+
+  constructor(config: ApiConfig) {
+    this.baseUrl = config.baseUrl;
+    this.headers = config.headers || {};
+  }
+
+  async get<T>(endpoint: string, options: RequestInit = {}): Promise<ApiResponse<T>> {
+    const response = await this.fetch(endpoint, {
+      method: 'GET',
+      ...options,
+    });
+
+    return (await response.json()) as ApiResponse<T>;
+  }
+
+  private async fetch(endpoint: string, options: RequestInit = {}): Promise<Response> {
+    const url = `${this.baseUrl}${endpoint}`;
+
+    const response = await fetch(url, {
+      headers: {
+        ...this.headers,
+        ...options.headers,
+      },
+      ...options,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    return response;
+  }
+}
+

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,0 +1,11 @@
+import { AdvocateApi } from '@/lib/api/advocate-api';
+import { ApiClient } from '@/lib/api/api-client';
+
+const apiClient = new ApiClient({
+  baseUrl: process.env.API_URL || 'http://localhost:3000',
+  headers: {
+    'Content-Type': 'application/json'
+  },
+});
+
+export const advocateApi = new AdvocateApi(apiClient);


### PR DESCRIPTION
# What Changed?

Starting a new abstraction for backend APIs. Now in `lib` there is an `api` namespace that will be responsible for holding a simple SDK for interacting with the backend. This lets us centralize all these calls, and make it easy for them to be reusable and keep logic in one location.

- Adding `API_URL` to list of envs we need
- Created an `ApiClient` class that holds basics for calling the backend
- Created `AdvocateApi` class that uses the `ApiClient` to make advocate-specific API calls
- Updated the Home page to utilize this new class

## Screenshot/Video

## Related PRs


### Reminders

- Link to the related ticket
- Tests added or updated
- Add/Update related documentation
